### PR TITLE
Allow in-module adapter specification

### DIFF
--- a/lib/gen_queue.ex
+++ b/lib/gen_queue.ex
@@ -50,11 +50,17 @@ defmodule GenQueue do
   external libraries. Simply specify the adapter name in your config.
 
       config :my_app, MyApp.Enqueuer, [
-        adapter: GenQueue.MyAdapter
+        adapter: MyApp.MyAdapter
       ]
 
       defmodule MyApp.Enqueuer do
         use GenQueue, otp_app: :my_app
+      end
+
+  The custom adapter can also be specified for the module in-line:
+
+      defmodule MyApp.Enqueuer do
+        use GenQueue, adapter: MyApp.MyAdapter
       end
 
   We can then create our own adapter by creating an adapter module that handles
@@ -224,10 +230,15 @@ defmodule GenQueue do
     * `gen_queue` - GenQueue module to use
   """
   @spec config_adapter(GenQueue.t(), opts :: Keyword.t()) :: GenQueue.Adapter.t()
-  def config_adapter(gen_queue, opts \\ []) do
-    opts
-    |> Keyword.get(:otp_app)
+  def config_adapter(gen_queue, opts \\ [])
+
+  def config_adapter(_gen_queue, [adapter: adapter]) when is_atom(adapter), do: adapter
+
+  def config_adapter(gen_queue, [otp_app: app]) when is_atom(app) do
+    app
     |> Application.get_env(gen_queue, [])
     |> Keyword.get(:adapter, @default_adapter)
   end
+
+  def config_adapter(_gen_queue, _opts), do: @default_adapter
 end

--- a/test/gen_queue/test_test.exs
+++ b/test/gen_queue/test_test.exs
@@ -11,41 +11,81 @@ defmodule GenQueue.TestTest do
     end
   end
 
-  defmodule Queue do
+  defmodule AppQueue do
     Application.put_env(:gen_queue, __MODULE__, adapter: GenQueue.TestTest.Adapter)
 
     use GenQueue, otp_app: :gen_queue
   end
 
-  describe "setup_test_queue/1" do
+  defmodule ModQueue do
+    Application.put_env(:gen_queue, __MODULE__, adapter: GenQueue.TestTest.Adapter)
+
+    use GenQueue, adapter: GenQueue.TestTest.Adapter
+  end
+
+  describe "app_config: setup_test_queue/1" do
     test "will return the item back to the current process" do
-      setup_test_queue(Queue)
-      Queue.push(:foo)
+      setup_test_queue(AppQueue)
+      AppQueue.push(:foo)
       assert_receive(:foo)
     end
   end
 
-  describe "setup_global_test_queue/2" do
+  describe "app_config: setup_global_test_queue/2" do
     test "will name the current process" do
-      setup_global_test_queue(Queue, :test)
+      setup_global_test_queue(AppQueue, :test)
       assert self() == Process.whereis(:test)
     end
 
     test "will return the item back to the named process" do
-      setup_global_test_queue(Queue, :test)
-      Queue.push(:foo)
+      setup_global_test_queue(AppQueue, :test)
+      AppQueue.push(:foo)
       assert_receive(:foo)
     end
   end
 
-  describe "reset_test_queue/1" do
+  describe "app_config: reset_test_queue/1" do
     test "will remove any current return processes" do
-      setup_test_queue(Queue)
-      Queue.push(:foo)
+      setup_test_queue(AppQueue)
+      AppQueue.push(:foo)
       assert_receive(:foo)
 
-      reset_test_queue(Queue)
-      Queue.push(:foo)
+      reset_test_queue(AppQueue)
+      AppQueue.push(:foo)
+
+      assert {:message_queue_len, 0} = Process.info(self(), :message_queue_len)
+    end
+  end
+
+  describe "mod_config: setup_test_queue/1" do
+    test "will return the item back to the current process" do
+      setup_test_queue(ModQueue)
+      ModQueue.push(:foo)
+      assert_receive(:foo)
+    end
+  end
+
+  describe "mod_config: setup_global_test_queue/2" do
+    test "will name the current process" do
+      setup_global_test_queue(ModQueue, :test)
+      assert self() == Process.whereis(:test)
+    end
+
+    test "will return the item back to the named process" do
+      setup_global_test_queue(ModQueue, :test)
+      ModQueue.push(:foo)
+      assert_receive(:foo)
+    end
+  end
+
+  describe "mod_config: reset_test_queue/1" do
+    test "will remove any current return processes" do
+      setup_test_queue(ModQueue)
+      ModQueue.push(:foo)
+      assert_receive(:foo)
+
+      reset_test_queue(ModQueue)
+      ModQueue.push(:foo)
 
       assert {:message_queue_len, 0} = Process.info(self(), :message_queue_len)
     end


### PR DESCRIPTION
- This allows a consuming application to specify more than one type of backing
  queue.